### PR TITLE
Decouple coordinator from entities.

### DIFF
--- a/custom_components/maestro_mcz/__init__.py
+++ b/custom_components/maestro_mcz/__init__.py
@@ -1,30 +1,41 @@
 """The maestro_mcz integration."""
 from __future__ import annotations
+from datetime import timedelta
+import logging
+import async_timeout
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant import config_entries
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
-from .maestro import MaestroController
+from .maestro import MaestroController, MaestroStove
 
 PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up maestro_mcz from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
-    controller = MaestroController(entry.data["username"], entry.data["password"])
-    await controller.Login()
-    hass.data[DOMAIN][entry.entry_id] = controller
+    maestroapi = MaestroController(entry.data["username"], entry.data["password"])
+    await maestroapi.Login()
+
+    stoveList = []
+    for stove in maestroapi.Stoves:
+        stove:MaestroStove = stove
+        coordinator = MczCoordinator(hass, stove)
+        await coordinator.async_config_entry_first_refresh()
+        stoveList.append(coordinator)
+
+    hass.data[DOMAIN][entry.entry_id] = stoveList
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
-
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
@@ -32,3 +43,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+class MczCoordinator(DataUpdateCoordinator):
+    """MCZ Coordinator."""
+
+    def __init__(self, hass, maestroapi):
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="MCZ Stove",
+            update_interval=timedelta(seconds=30),
+        )
+        self._maestroapi:MaestroStove = maestroapi
+
+    async def _async_update_data(self):
+        """Fetch data from API endpoint."""
+        async with async_timeout.timeout(15):
+            await self._maestroapi.Refresh()
+            return True
+    
+    @property
+    def maestroapi(self) -> MaestroStove:
+        return self._maestroapi


### PR DESCRIPTION
The aim of this PR is to decouple the data update from the entities.
In the current setup, each entity had their own update coordinator, meaning for a single stove, 1 climate and 1 sensor would fetch the same data twice.

The coordinator is now instantiated once, and passed along to all entities.
1 coordinator per stove is still required, as each stove has to be polled separately.