### PR TITLE
Stove info

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -66,8 +66,10 @@ class MczEntity(CoordinatorEntity, ClimateEntity):
             identifiers={(DOMAIN, self.coordinator._maestroapi.Status.sm_sn)},
             name=self.coordinator._maestroapi.Name,
             manufacturer="MCZ",
-            model=self.coordinator._maestroapi.Status.nome_banca_dati_sel,
-            sw_version=self.coordinator._maestroapi.Status.mc_vs_app,
+            model=self.coordinator._maestroapi.Model.model_name,
+            sw_version=f"{self.coordinator._maestroapi.Status.sm_nome_app}.{self.coordinator._maestroapi.Status.sm_vs_app}"
+            + f", Panel:{self.coordinator._maestroapi.Status.mc_vs_app}"
+            + f", DB:{self.coordinator._maestroapi.Status.nome_banca_dati_sel}",
         )
 
     @property

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -53,11 +53,7 @@ class MczEntity(CoordinatorEntity, FanEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator._maestroapi.Status.sm_sn)},
-            name=self.coordinator._maestroapi.Name,
-            manufacturer="MCZ",
-            model=self.coordinator._maestroapi.Status.nome_banca_dati_sel,
-            sw_version=self.coordinator._maestroapi.Status.mc_vs_app,
+            identifiers={(DOMAIN, self.coordinator._maestroapi.Status.sm_sn)}
         )
 
     @property

--- a/custom_components/maestro_mcz/manifest.json
+++ b/custom_components/maestro_mcz/manifest.json
@@ -12,5 +12,5 @@
       "@Robbe-B"  
     ],
     "iot_class": "cloud_polling",
-    "version": "0.2.6-beta"
+    "version": "0.2.9-beta"
 }

--- a/custom_components/maestro_mcz/sensor.py
+++ b/custom_components/maestro_mcz/sensor.py
@@ -45,7 +45,7 @@ class MczEntity(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator._maestroapi.Status.sm_sn)},
+            identifiers={(DOMAIN, self.coordinator._maestroapi.Status.sm_sn)}
         )
 
     @property


### PR DESCRIPTION
The device info is now more correct.

[Model] is now the model name from the API instead of the database version
[Firmware] is now the different firmware versions composed and shown as the Maestro MCZ app

Before:
![image](https://user-images.githubusercontent.com/103053873/228554884-9fd44de3-52cc-4e3c-a7e0-ef07feffd32a.png)
After:
![image](https://user-images.githubusercontent.com/103053873/228554639-38a29752-bc62-41e9-9770-7733f094e15d.png)

Screenshot Maestro MCZ app:
