### PR TITLE
Dynamic config - First steps towards a full automatic stove config detection

### DIFF
--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -178,9 +178,7 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         if(self.power_configuration is not None):
-            if(hvac_mode == HVACMode.OFF or hvac_mode == HVACMode.HEAT):
-                converted_hvac_mode = (hvac_mode == HVACMode.HEAT)
-                await self.coordinator._maestroapi.ActivateProgram(self.power_configuration.configuration.sensor_id, self.power_configuration.configuration_id, converted_hvac_mode)
+                await self.coordinator._maestroapi.ActivateProgram(self.power_configuration.configuration.sensor_id, self.power_configuration.configuration_id, True)
                 await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode):

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -116,12 +116,12 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
     def set_power_configuration(self, matching_power_configuration: SensorConfiguration):
         self.power_configuration = matching_power_configuration
-        if(matching_power_configuration.configuration.type == TypeEnum.BOOLEAN):
+        if(matching_power_configuration.configuration.type == TypeEnum.BOOLEAN.value):
             self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
 
     def set_thermostat_configuration(self, matching_thermostat_configuration: SensorConfiguration):
         self.thermostat_configuration = matching_thermostat_configuration
-        if(matching_thermostat_configuration.configuration.type == TypeEnum.DOUBLE):
+        if(matching_thermostat_configuration.configuration.type == TypeEnum.DOUBLE.value):
             self._attr_min_temp = float(matching_thermostat_configuration.configuration.min)
             self._attr_max_temp = float(matching_thermostat_configuration.configuration.max)
             self._attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -129,7 +129,7 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
     
     def set_climate_function_mode_configuration(self, matching_climate_function_mode_configuration: SensorConfiguration):
         self.climate_function_mode_configuration = matching_climate_function_mode_configuration
-        if(matching_climate_function_mode_configuration.configuration.type == TypeEnum.INT):
+        if(matching_climate_function_mode_configuration.configuration.type == TypeEnum.INT.value):
             self._attr_preset_modes = []
             self._attr_preset_modes_mappings = matching_climate_function_mode_configuration.configuration.mappings
             for key in matching_climate_function_mode_configuration.configuration.variants:
@@ -144,13 +144,13 @@ class MczClimateEntity(CoordinatorEntity, ClimateEntity):
 
     def set_pot_configuration(self, matching_pot_configuration: SensorConfiguration):
         self.pot_configuration = matching_pot_configuration
-        if(matching_pot_configuration.configuration.type == TypeEnum.INT):
+        if(matching_pot_configuration.configuration.type == TypeEnum.INT.value):
             self._attr_swing_modes = list(map(str,range(int(matching_pot_configuration.configuration.min), int(matching_pot_configuration.configuration.max) + 1 , 1)))
             self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
 
     def set_fan_configuration(self, matching_fan_configuration: SensorConfiguration):
         self.fan_configuration = matching_fan_configuration
-        if(matching_fan_configuration.configuration.type == TypeEnum.INT):
+        if(matching_fan_configuration.configuration.type == TypeEnum.INT.value):
             self._attr_fan_modes = list(map(str,range(int(matching_fan_configuration.configuration.min), int(matching_fan_configuration.configuration.max) + 1 , 1)))
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 

--- a/custom_components/maestro_mcz/climate.py
+++ b/custom_components/maestro_mcz/climate.py
@@ -1,5 +1,9 @@
 """Platform for Climate integration."""
 import logging
+from uuid import UUID
+
+from custom_components.maestro_mcz import models
+from custom_components.maestro_mcz.maestro.responses.model import Configuration, SensorConfiguration
 
 from . import MczCoordinator
 
@@ -15,54 +19,59 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from .const import DOMAIN
-from .maestro.types.mode import ModeEnum
+from .maestro.types.enums import TypeEnum
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    stoveList = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(MczEntity(stove) for stove in stoveList)
+    stove_list = hass.data[DOMAIN][entry.entry_id]
+    entities = []
+    for stove in stove_list:
+        stove:MczCoordinator = stove
+        first_supported_power_sensor = stove.get_first_matching_sensor_configuration_by_model_configuration_name_and_sensor_name(models.supported_power_settings)
+        if(first_supported_power_sensor is not None and first_supported_power_sensor[0] is not None and first_supported_power_sensor[1] is not None):
+            entities.append(MczClimateEntity(stove, first_supported_power_sensor[0], first_supported_power_sensor[1]))
+            
+    async_add_entities(entities)
 
-class MczEntity(CoordinatorEntity, ClimateEntity):
+class MczClimateEntity(CoordinatorEntity, ClimateEntity):
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator:MczCoordinator):
+    def __init__(self, coordinator:MczCoordinator, supported_power_sensor: models.PowerSettingMczConfigItem, matching_power_configuration: SensorConfiguration):
         super().__init__(coordinator)
         self.coordinator:MczCoordinator = coordinator
-        self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
-        self._attr_fan_modes = ["0", "1", "2", "3", "4", "5", "6"]
-        self._attr_swing_modes = ["1", "2", "3", "4", "5"]
-        self._attr_preset_modes = ["manual", "auto", "overnight", "comfort", "turbo"]
-        self._attr_min_temp = 5
-        self._attr_max_temp = 40
+        
+        #general 
         self._attr_name = None
-        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_unique_id = f"{self.coordinator._maestroapi.Status.sm_sn}"
         self._attr_icon = "mdi:stove"
 
-    _attr_supported_features = (
-        ClimateEntityFeature.FAN_MODE
-        | ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.SWING_MODE
-        | ClimateEntityFeature.PRESET_MODE
-    )
+        #set power on/off config
+        self.supported_power_sensor = supported_power_sensor
+        self.set_power_configuration(matching_power_configuration)
 
-    @property
-    def hvac_mode(self) -> HVACMode:
-        if(self.coordinator._maestroapi.Status.fase_op.lower() == "on" or 
-        self.coordinator._maestroapi.Status.fase_op.lower() =="turning-on"):
-            return HVACMode.HEAT
-        else: # turning-off | off | cooling-down
-            return HVACMode.OFF
-                        
-            
+        #set thermostat config 
+        first_supported_thermostat = coordinator.get_first_matching_sensor_configuration_by_model_configuration_name_and_sensor_name(models.supported_thermostats)
+        if(first_supported_thermostat is not None and first_supported_thermostat[0] is not None and first_supported_thermostat[1] is not None):
+            self.supported_thermostat = first_supported_thermostat[0]
+            self.set_thermostat_configuration(first_supported_thermostat[1])
 
-    @property
-    def fan_mode(self) -> str:
-        return str(self.coordinator._maestroapi.Status.set_vent_v1)
+        #set preset config
+        first_supported_climate_function_mode = coordinator.get_first_matching_sensor_configuration_by_model_configuration_name_and_sensor_name(models.supported_climate_function_modes)
+        if(first_supported_climate_function_mode is not None and first_supported_climate_function_mode[0] is not None and first_supported_climate_function_mode[1] is not None):
+            self.supported_climate_function_mode = first_supported_climate_function_mode[0]
+            self.set_climate_function_mode_configuration(first_supported_climate_function_mode[1])
 
-    @property
-    def swing_mode(self) -> str:
-        return str(self.coordinator._maestroapi.Status.set_pot_man)
+        #set pot config
+        first_supported_pot = coordinator.get_first_matching_sensor_configuration_by_model_configuration_name_and_sensor_name(models.supported_pots)
+        if(first_supported_pot is not None and first_supported_pot[0] is not None and first_supported_pot[1] is not None):
+            self.supported_pot = first_supported_pot[0]
+            self.set_pot_configuration(first_supported_pot[1])
 
+        #set fan config
+        first_supported_fan = coordinator.get_first_matching_sensor_configuration_by_model_configuration_name_and_sensor_name(models.supported_fans)
+        if(first_supported_fan is not None and first_supported_fan[0] is not None and first_supported_fan[1] is not None):
+            self.supported_fan = first_supported_fan[0]
+            self.set_fan_configuration(first_supported_fan[1])
+                               
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
@@ -74,43 +83,105 @@ class MczEntity(CoordinatorEntity, ClimateEntity):
             + f", Panel:{self.coordinator._maestroapi.Status.mc_vs_app}"
             + f", DB:{self.coordinator._maestroapi.Status.nome_banca_dati_sel}",
         )
+    
+    @property
+    def hvac_mode(self) -> HVACMode:
+        fase_op = getattr(self.coordinator._maestroapi.Status, self.supported_power_sensor.sensor_get_name)
+        if(fase_op is not None):
+            if(str(fase_op).lower() == "on" or str(fase_op).lower() == "turning-on"):
+                return HVACMode.HEAT
+            else: # turning-off | off | cooling-down
+                return HVACMode.OFF
+        
+    @property
+    def fan_mode(self) -> str:
+        return str(getattr(self.coordinator._maestroapi.Status, self.supported_fan.sensor_get_name))
 
     @property
-    def current_temperature(self):
+    def swing_mode(self) -> str:
+        return str(getattr(self.coordinator._maestroapi.Status, self.supported_pot.sensor_get_name))
+
+    @property
+    def current_temperature(self): #ToDo in case there can be different => needs more investigation in the future
         return self.coordinator._maestroapi.State.temp_amb_install
 
     @property
     def target_temperature(self):
-        return self.coordinator._maestroapi.State.set_amb1
+        return getattr(self.coordinator._maestroapi.State, self.supported_thermostat.sensor_get_name)
 
     @property
     def preset_mode(self):
-        return self.coordinator._maestroapi.State.mode
+        return str(getattr(self.coordinator._maestroapi.State, self.supported_climate_function_mode.sensor_get_name))
+
+
+    def set_power_configuration(self, matching_power_configuration: SensorConfiguration):
+        self.power_configuration = matching_power_configuration
+        if(matching_power_configuration.configuration.type == TypeEnum.BOOLEAN):
+            self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+
+    def set_thermostat_configuration(self, matching_thermostat_configuration: SensorConfiguration):
+        self.thermostat_configuration = matching_thermostat_configuration
+        if(matching_thermostat_configuration.configuration.type == TypeEnum.DOUBLE):
+            self._attr_min_temp = float(matching_thermostat_configuration.configuration.min)
+            self._attr_max_temp = float(matching_thermostat_configuration.configuration.max)
+            self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+    
+    def set_climate_function_mode_configuration(self, matching_climate_function_mode_configuration: SensorConfiguration):
+        self.climate_function_mode_configuration = matching_climate_function_mode_configuration
+        if(matching_climate_function_mode_configuration.configuration.type == TypeEnum.INT):
+            self._attr_preset_modes = []
+            self._attr_preset_modes_mappings = matching_climate_function_mode_configuration.configuration.mappings
+            for key in matching_climate_function_mode_configuration.configuration.variants:
+                if key in self.supported_climate_function_mode.mappings.keys():
+                    self._attr_preset_modes.append(self.supported_climate_function_mode.mappings[key])
+                    #Add the internal mapped key (from the config) in the public mappings (api mappings), with same value but mapped key
+                    if(key in self._attr_preset_modes_mappings):
+                        self._attr_preset_modes_mappings[self.supported_climate_function_mode.mappings[key]] = self._attr_preset_modes_mappings[key]
+                else:
+                    self._attr_preset_modes.append(key)
+            self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
+
+    def set_pot_configuration(self, matching_pot_configuration: SensorConfiguration):
+        self.pot_configuration = matching_pot_configuration
+        if(matching_pot_configuration.configuration.type == TypeEnum.INT):
+            self._attr_swing_modes = list(map(str,range(int(matching_pot_configuration.configuration.min), int(matching_pot_configuration.configuration.max) + 1 , 1)))
+            self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
+
+    def set_fan_configuration(self, matching_fan_configuration: SensorConfiguration):
+        self.fan_configuration = matching_fan_configuration
+        if(matching_fan_configuration.configuration.type == TypeEnum.INT):
+            self._attr_fan_modes = list(map(str,range(int(matching_fan_configuration.configuration.min), int(matching_fan_configuration.configuration.max) + 1 , 1)))
+            self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
     async def async_set_preset_mode(self, preset_mode):
-        await self.coordinator._maestroapi.Mode(ModeEnum[preset_mode])
+        if preset_mode in self._attr_preset_modes_mappings.keys():
+            converted_preset_mode = self._attr_preset_modes_mappings[preset_mode]
+        else:
+            return #should never happen
+        await self.coordinator._maestroapi.ActivateProgram(self.climate_function_mode_configuration.configuration.sensor_id, self.climate_function_mode_configuration.configuration_id, converted_preset_mode)
         await self.coordinator.async_request_refresh()
 
     async def async_set_hvac_mode(self, hvac_mode):
-        await self.coordinator._maestroapi.Power()
+        await self.coordinator._maestroapi.ActivateProgram(self.power_configuration.configuration.sensor_id, self.power_configuration.configuration_id, True)
         await self.coordinator.async_request_refresh()
 
     async def async_set_fan_mode(self, fan_mode):
-        await self.coordinator._maestroapi.Fan(1,int(fan_mode))
+        await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, int(fan_mode))
         await self.coordinator.async_request_refresh()
 
     async def async_set_swing_mode(self, swing_mode):
-        await self.coordinator._maestroapi.Pot(int(swing_mode))
+        await self.coordinator._maestroapi.ActivateProgram(self.pot_configuration.configuration.sensor_id, self.pot_configuration.configuration_id,int(swing_mode))
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs):
-        await self.coordinator._maestroapi.Temperature(float(kwargs["temperature"]))
+        await self.coordinator._maestroapi.ActivateProgram(self.thermostat_configuration.configuration.sensor_id, self.thermostat_configuration.configuration_id, float(kwargs["temperature"]))
         await self.coordinator.async_request_refresh()
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        self._attr_target_temperature = self.coordinator._maestroapi.State.set_amb1
-        self._attr_fan_mode = str(self.coordinator._maestroapi.Status.set_vent_v1)
-        self._attr_swing_mode = str(self.coordinator._maestroapi.Status.set_pot_man)
-        self._attr_preset_mode = self.coordinator._maestroapi.State.mode
+        self._attr_target_temperature = getattr(self.coordinator._maestroapi.State, self.supported_thermostat.sensor_get_name)
+        self._attr_fan_mode = str(getattr(self.coordinator._maestroapi.Status, self.supported_fan.sensor_get_name))
+        self._attr_swing_mode = str(getattr(self.coordinator._maestroapi.Status, self.supported_pot.sensor_get_name))   
+        self._attr_preset_mode = str(getattr(self.coordinator._maestroapi.State, self.supported_climate_function_mode.sensor_get_name))
         self.async_write_ha_state()

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -47,7 +47,7 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
         self._enabled_default = supported_fan.enabled_by_default
         self._category = supported_fan.category
         self.fan_configuration = matching_fan_configuration
-        if(matching_fan_configuration.configuration.type == TypeEnum.INT):
+        if(matching_fan_configuration.configuration.type == TypeEnum.INT.value):
             self._presets = self._attr_preset_modes = list(map(str,range(int(matching_fan_configuration.configuration.min), int(matching_fan_configuration.configuration.max) + 1 , 1)))
             self._attr_supported_features = (FanEntityFeature.PRESET_MODE)
 

--- a/custom_components/maestro_mcz/fan.py
+++ b/custom_components/maestro_mcz/fan.py
@@ -65,7 +65,10 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
 
     @property
     def is_on(self) -> bool:
-        return self.preset_mode != self._presets[0]
+        if(self.fan_configuration is not None and self._presets is not None and len(self._presets) > 0):
+            return self.preset_mode != self._presets[0]
+        else:
+            return False
 
     @property
     def preset_mode(self) -> str:
@@ -82,18 +85,21 @@ class MczFanEntity(CoordinatorEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
-        await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, int(preset_mode))
-        await self.coordinator.async_request_refresh()
+        if(self.fan_configuration is not None):
+            await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, int(preset_mode))
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self) -> None:
         """Turn on the fan."""
-        await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, self._presets[-1])
-        await self.coordinator.async_request_refresh()
+        if(self.fan_configuration is not None):
+            await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, self._presets[-1])
+            await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self) -> None:
         """Turn the fan off."""
-        await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, self._presets[0])
-        await self.coordinator.async_request_refresh()
+        if(self.fan_configuration is not None):
+            await self.coordinator._maestroapi.ActivateProgram(self.fan_configuration.configuration.sensor_id, self.fan_configuration.configuration_id, self._presets[0])
+            await self.coordinator.async_request_refresh()
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/maestro_mcz/maestro/__init__.py
+++ b/custom_components/maestro_mcz/maestro/__init__.py
@@ -175,8 +175,8 @@ class MaestroStove:
         self._state = await self.StoveState()
         self._status = await self.StoveStatus()
 
-    async def ActivateProgram(self, sensor_id: UUID, configuration_id: UUID, value: object):
+    async def ActivateProgram(self, sensor_id: str, configuration_id: str, value: object):
         url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        command = [{"SensorId": str(sensor_id), "Value": value}]
-        body = RequestBuilder(self, ConfigurationId=str(configuration_id), Commands=command)
+        command = [{"SensorId": sensor_id, "Value": value}]
+        body = RequestBuilder(self, ConfigurationId=configuration_id, Commands=command)
         await self._controller.MakeRequest("POST", url=url, body=body)

--- a/custom_components/maestro_mcz/maestro/__init__.py
+++ b/custom_components/maestro_mcz/maestro/__init__.py
@@ -180,9 +180,3 @@ class MaestroStove:
         command = [{"SensorId": str(sensor_id), "Value": value}]
         body = RequestBuilder(self, ConfigurationId=str(configuration_id), Commands=command)
         await self._controller.MakeRequest("POST", url=url, body=body)
-
-    async def Fan(self, sensor_id: UUID, configuration_id: UUID, fan_value: int):
-        url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        command = [{"SensorId": str(sensor_id), "Value": fan_value}]
-        body = RequestBuilder(self, ConfigurationId=str(configuration_id), Commands=command)
-        await self._controller.MakeRequest("POST", url=url, body=body)

--- a/custom_components/maestro_mcz/maestro/__init__.py
+++ b/custom_components/maestro_mcz/maestro/__init__.py
@@ -1,4 +1,5 @@
 import json
+from uuid import UUID
 import aiohttp
 import asyncio
 import async_timeout
@@ -7,7 +8,6 @@ from .responses.model import Model
 from .responses.status import Status
 from .responses.state import State
 
-from .types.mode import ModeEnum
 from .http.request import RequestBuilder
 from .const import LOGIN_URL
 
@@ -175,50 +175,14 @@ class MaestroStove:
         self._state = await self.StoveState()
         self._status = await self.StoveStatus()
 
-    async def Mode(self, Mode: ModeEnum):
+    async def ActivateProgram(self, sensor_id: UUID, configuration_id: UUID, value: object):
         url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        configurationid = "d85b93a4-4cae-4745-925d-ef53547c661e"
-        command = [
-            {
-                "SensorId": "bd064ae8-9091-4696-b137-5a4e243ebb91",
-                "Value": int(Mode.value[0]),
-            }
-        ]
-        body = RequestBuilder(self, ConfigurationId=configurationid, Commands=command)
+        command = [{"SensorId": str(sensor_id), "Value": value}]
+        body = RequestBuilder(self, ConfigurationId=str(configuration_id), Commands=command)
         await self._controller.MakeRequest("POST", url=url, body=body)
 
-    async def Power(self):
+    async def Fan(self, sensor_id: UUID, configuration_id: UUID, fan_value: int):
         url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        configurationid = "e373bb67-fe69-4d49-b2f2-4b636fa68e37"
-        command = [{"SensorId": "9c7f0959-47a2-44ea-906d-f5d22218d00e", "Value": True}]
-        body = RequestBuilder(self, ConfigurationId=configurationid, Commands=command)
-        await self._controller.MakeRequest("POST", url=url, body=body)
-
-    async def Temperature(self, temp: float):
-        url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        configurationid = "875fb696-4af1-42da-bb78-ebe57c90fe5c"
-        command = [{"SensorId": "b866d2a9-d0ab-4558-8367-910c52261be1", "Value": temp}]
-        body = RequestBuilder(self, ConfigurationId=configurationid, Commands=command)
-        await self._controller.MakeRequest("POST", url=url, body=body)
-
-    async def Fan(self, fan_number: int, fan_value: int):
-        url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        match fan_number :
-            case 1: 
-                configurationid = "bcb11620-e1f0-419f-ba03-db4651c34017"
-                command = [{"SensorId": "72aac073-1815-4d52-bb2e-2ed7d1c78e1f", "Value": fan_value}]
-            case 2: 
-                configurationid = "edc8c0b7-ce59-4433-870d-f011c5e4fd0f"
-                command = [{"SensorId": "1a0b9674-8418-4dbe-a3a8-cefd12998186", "Value": fan_value}]
-            case 3: 
-                configurationid = "25fc45eb-be51-4f23-a8ce-31215f75a2ec"
-                command = [{"SensorId": "63e65772-af9e-4545-b9c2-e4ca082b827f", "Value": fan_value}]
-        body = RequestBuilder(self, ConfigurationId=configurationid, Commands=command)
-        await self._controller.MakeRequest("POST", url=url, body=body)
-
-    async def Pot(self, pot: int):
-        url = f"https://s.maestro.mcz.it/mcz/v1.0/Program/ActivateProgram/{self.Id}"
-        configurationid = "fa2e1c9e-83e3-4435-825b-cdfb50da92a7"
-        command = [{"SensorId": "f7750f3e-9ff2-4351-b53a-6d1a9d1f6bc6", "Value": pot}]
-        body = RequestBuilder(self, ConfigurationId=configurationid, Commands=command)
+        command = [{"SensorId": str(sensor_id), "Value": fan_value}]
+        body = RequestBuilder(self, ConfigurationId=str(configuration_id), Commands=command)
         await self._controller.MakeRequest("POST", url=url, body=body)

--- a/custom_components/maestro_mcz/maestro/responses/model.py
+++ b/custom_components/maestro_mcz/maestro/responses/model.py
@@ -1,66 +1,65 @@
 from dataclasses import dataclass, field
-from uuid import UUID
 from ..types.enums import TypeEnum
 
 @dataclass
 class Configuration:
-    sensor_name: str
-    type: TypeEnum
-    visible: bool
-    variants: list[str]
-    sensor_id: UUID
-    enabled: bool
-    min: str
-    max: str
-    mappings: dict[str, int]
+    sensor_name: str | None = None
+    type: str | None = None
+    visible: bool | None = None
+    variants: list[str] | None = None
+    sensor_id: str | None = None
+    enabled: bool | None = None
+    min: str | None = None
+    max: str | None = None
+    mappings: dict[str, int] | None = None
 
     def __init__(self, json) -> None:
-        self.sensor_name = str(json["SensorName"])
-        self.type = TypeEnum(json["Type"])
-        self.visible = bool(json["Visible"])
-        self.variants = [str(variant) for variant in json["Variants"]]
-        self.sensor_id = UUID(json["SensorId"])
-        self.enabled = bool(json["Enabled"])
-        self.min = str(json["Min"])
-        self.max = str(json["Max"])
-        self.mappings = dict[str, int](json["Mappings"])
+        self.sensor_name = json["SensorName"]
+        self.type = json["Type"]
+        self.visible = json["Visible"]
+        self.variants = json["Variants"]
+        self.sensor_id = json["SensorId"]
+        self.enabled = json["Enabled"]
+        self.min = json["Min"]
+        self.max = json["Max"]
+        self.mappings = json["Mappings"]
 
 @dataclass
 class ModelConfiguration:
-    timed: bool
-    configuration_name: str
-    configurations: list[Configuration]
-    configuration_id: UUID
-    limitations: str
+    timed: bool | None = None
+    configuration_name: str | None = None
+    configurations: list[Configuration] | None = None
+    configuration_id: str | None = None
+    limitations: str | None = None
 
     def __init__(self, json) -> None:
-        self.timed = bool(json["Timed"])
-        self.configuration_name = str(json["ConfigurationName"])
+        self.timed = json["Timed"]
+        self.configuration_name = json["ConfigurationName"]
         self.configurations = [Configuration(configuration) for configuration in json["Configurations"]]
-        self.configuration_id = UUID(json["ConfigurationId"])
-        self.limitations = str(json["Limitations"])
+        self.configuration_id = json["ConfigurationId"]
+        self.limitations = json["Limitations"]
 
 @dataclass
 class Model:
-    model_configurations: list[ModelConfiguration]
-    model_name: str
-    model_id: str
-    sensor_set_type_id: str
-    sensor_ids: list[UUID]
-    properties: list[str]
+    model_configurations: list[ModelConfiguration] | None = None
+    model_name: str | None = None
+    model_id: str | None = None
+    sensor_set_type_id: str | None = None
+    sensor_ids: list[str] | None = None
+    properties: list[str] | None = None
 
     def __init__(self, json) -> None:
         self.model_configurations = [ModelConfiguration(model_configuration) for model_configuration in json["ModelConfigurations"]]
-        self.model_name = str(json["ModelName"])
-        self.model_id = str(json["ModelId"])
-        self.sensor_set_type_id = str(json["SensorSetTypeId"])
-        self.sensor_ids = [UUID(sensor_id) for sensor_id in json["SensorIds"]]
-        self.properties = [str(property) for property in json["Properties"]]
+        self.model_name = json["ModelName"]
+        self.model_id = json["ModelId"]
+        self.sensor_set_type_id = json["SensorSetTypeId"]
+        self.sensor_ids = json["SensorIds"]
+        self.properties = json["Properties"]
 
 @dataclass
 class SensorConfiguration:
-    configuration: Configuration
-    configuration_id: str
+    configuration: Configuration | None = None
+    configuration_id: str | None = None
 
     def __init__(self, configuration: Configuration, configuration_id: str) -> None:
         self.configuration = configuration

--- a/custom_components/maestro_mcz/maestro/responses/model.py
+++ b/custom_components/maestro_mcz/maestro/responses/model.py
@@ -1,29 +1,29 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
-from ..types.mode import TypeEnum
+from ..types.enums import TypeEnum
 
 @dataclass
 class Configuration:
     sensor_name: str
     type: TypeEnum
     visible: bool
-    variants: list[str] 
-    sensor_id: str
+    variants: list[str]
+    sensor_id: UUID
     enabled: bool
-    min: object
-    max: object
+    min: str
+    max: str
     mappings: dict[str, int]
 
     def __init__(self, json) -> None:
-        self.sensor_name = json["SensorName"]
-        self.type = json["Type"]
-        self.visible = json["Visible"]
-        self.variants = json["Variants"]
-        self.sensor_id = json["SensorId"]
-        self.enabled = json["Enabled"]
-        self.min = json["Min"]
-        self.max = json["Max"]
-        self.mappings = json["Mappings"]
+        self.sensor_name = str(json["SensorName"])
+        self.type = TypeEnum(json["Type"])
+        self.visible = bool(json["Visible"])
+        self.variants = [str(variant) for variant in json["Variants"]]
+        self.sensor_id = UUID(json["SensorId"])
+        self.enabled = bool(json["Enabled"])
+        self.min = str(json["Min"])
+        self.max = str(json["Max"])
+        self.mappings = dict[str, int](json["Mappings"])
 
 @dataclass
 class ModelConfiguration:
@@ -34,11 +34,11 @@ class ModelConfiguration:
     limitations: str
 
     def __init__(self, json) -> None:
-        self.timed = json["Timed"]
-        self.configuration_name = json["ConfigurationName"]
-        self.configurations = json["Configurations"]
-        self.configuration_id = json["ConfigurationId"]
-        self.limitations = json["Limitations"]
+        self.timed = bool(json["Timed"])
+        self.configuration_name = str(json["ConfigurationName"])
+        self.configurations = [Configuration(configuration) for configuration in json["Configurations"]]
+        self.configuration_id = UUID(json["ConfigurationId"])
+        self.limitations = str(json["Limitations"])
 
 @dataclass
 class Model:
@@ -50,9 +50,18 @@ class Model:
     properties: list[str]
 
     def __init__(self, json) -> None:
-        self.model_configurations = json["ModelConfigurations"]
-        self.model_name = json["ModelName"]
-        self.model_id = json["ModelId"]
-        self.sensor_set_type_id = json["SensorSetTypeId"]
-        self.sensor_ids = json["SensorIds"]
-        self.properties = json["Properties"]
+        self.model_configurations = [ModelConfiguration(model_configuration) for model_configuration in json["ModelConfigurations"]]
+        self.model_name = str(json["ModelName"])
+        self.model_id = str(json["ModelId"])
+        self.sensor_set_type_id = str(json["SensorSetTypeId"])
+        self.sensor_ids = [UUID(sensor_id) for sensor_id in json["SensorIds"]]
+        self.properties = [str(property) for property in json["Properties"]]
+
+@dataclass
+class SensorConfiguration:
+    configuration: Configuration
+    configuration_id: str
+
+    def __init__(self, configuration: Configuration, configuration_id: str) -> None:
+        self.configuration = configuration
+        self.configuration_id = configuration_id

--- a/custom_components/maestro_mcz/maestro/responses/state.py
+++ b/custom_components/maestro_mcz/maestro/responses/state.py
@@ -1,76 +1,92 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import logging
+
+
+
+_LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class State:
-    vel_imp_ventola_fumi: int
-    vel_real_ventola_fumi: int
-    vel_imp_coclea: int
-    vel_real_coclea: int
-    pressione: int
-    pressione_imp: int
-    temp_scheda: float
-    index_vel_v1: int
-    index_vel_v2: int
-    index_vel_v3: int
-    potenza_att: int
-    potenza_counter: int
-    t_dur_pul: int
-    t_int_pul: int
-    state: str
-    state_duration: int
-    temp_fumi: int
-    mode: str
-    crono_enabled: bool
-    att_eco: bool
-    pul_brac: bool
-    ingr_amb: int
-    sens_liv_pellet: bool
-    nome_banca_dati_sel: str
-    adaptive_on: bool
-    last_alarm: str
-    set_amb1: float
-    temp_amb_install: float
-    status_timestamp: int
-    last_stdt: int
-    site_time_zone: str
-    blocking_event_id: None
-    description: str
-    is_connected: bool
-    is_in_error: bool
+    vel_imp_ventola_fumi: int | None = None
+    vel_real_ventola_fumi: int | None = None
+    vel_imp_coclea: int | None = None
+    vel_real_coclea: int | None = None
+    pressione: int | None = None
+    pressione_imp: int | None = None
+    temp_scheda: float | None = None
+    index_vel_v1: int | None = None
+    index_vel_v2: int | None = None
+    index_vel_v3: int | None = None
+    potenza_att: int | None = None
+    potenza_counter: int | None = None
+    t_dur_pul: int | None = None
+    t_int_pul: int | None = None
+    state: str | None = None
+    state_duration: int | None = None
+    temp_fumi: int | None = None
+    mode: str | None = None
+    crono_enabled: bool | None = None
+    att_eco: bool | None = None
+    pul_brac: bool | None = None
+    ingr_amb: int | None = None
+    sens_liv_pellet: bool | None = None
+    nome_banca_dati_sel: str | None = None
+    adaptive_on: bool | None = None
+    last_alarm: str | None = None
+    set_amb1: float | None = None
+    temp_amb_install: float | None = None
+    status_timestamp: int | None = None
+    last_stdt: int | None = None
+    site_time_zone: str | None = None
+    blocking_event_id: str | None = None
+    description: str | None = None
+    is_connected: bool | None = None
+    is_in_error: bool | None = None
+
+    unknown_fields: dict | None = None
 
     def __init__(self, json) -> None:
-        self.vel_imp_ventola_fumi = json["vel_imp_ventola_fumi"]
-        self.vel_real_ventola_fumi = json["vel_real_ventola_fumi"]
-        self.vel_imp_coclea = json["vel_imp_coclea"]
-        self.vel_real_coclea = json["vel_real_coclea"]
-        self.pressione = json["pressione"]
-        self.pressione_imp = json["pressione_imp"]
-        self.temp_scheda = json["temp_scheda"]
-        self.index_vel_v1 = json["index_vel_v1"]
-        self.index_vel_v2 = json["index_vel_v2"]
-        self.index_vel_v3 = json["index_vel_v3"]
-        self.potenza_att = json["potenza_att"]
-        self.potenza_counter = json["potenza_counter"]
-        self.t_dur_pul = json["t_dur_pul"]
-        self.t_int_pul = json["t_int_pul"]
-        self.state = json["state"]
-        self.state_duration = json["state_duration"]
-        self.temp_fumi = json["temp_fumi"]
-        self.mode = json["mod_lav_att"]
-        self.crono_enabled = json["crono_enabled"]
-        self.att_eco = json["att_eco"]
-        self.pul_brac = json["pul_brac"]
-        self.ingr_amb = json["ingr_amb"]
-        self.sens_liv_pellet = json["sens_liv_pellet"]
-        self.nome_banca_dati_sel = json["nome_banca_dati_sel"]
-        self.adaptive_on = json["adaptive_on"]
-        self.last_alarm = json["last_alarm"]
-        self.set_amb1 = json["set_amb1"]
-        self.temp_amb_install = json["temp_amb_install"]
-        self.status_timestamp = json["StatusTimestamp"]
-        self.last_stdt = json["LastSTDT"]
-        self.site_time_zone = json["SiteTimeZone"]
-        self.blocking_event_id = json["BlockingEventId"]
-        self.description = json["Description"]
-        self.is_connected = json["IsConnected"]
-        self.is_in_error = json["IsInError"]
+         if(json is not None and len(json) > 0):
+            temp_unknown_fields = {}
+            for key in json:
+                match key:
+                    case "vel_imp_ventola_fumi": self.vel_imp_ventola_fumi = json[key]
+                    case "vel_real_ventola_fumi": self.vel_real_ventola_fumi = json[key]
+                    case "vel_imp_coclea": self.vel_imp_coclea = json[key]
+                    case "vel_real_coclea": self.vel_real_coclea = json[key]
+                    case "pressione": self.pressione = json[key]
+                    case "pressione_imp": self.pressione_imp = json[key]
+                    case "temp_scheda": self.temp_scheda = json[key]
+                    case "index_vel_v1": self.index_vel_v1 = json[key]
+                    case "index_vel_v2": self.index_vel_v2 = json[key]
+                    case "index_vel_v3": self.index_vel_v3 = json[key]
+                    case "potenza_att": self.potenza_att = json[key]
+                    case "potenza_counter": self.potenza_counter = json[key]
+                    case "t_dur_pul": self.t_dur_pul = json[key]
+                    case "t_int_pul": self.t_int_pul = json[key]
+                    case "state": self.state = json[key]
+                    case "state_duration": self.state_duration = json[key]
+                    case "temp_fumi": self.temp_fumi = json[key]
+                    case "mod_lav_att": self.mode = json[key]
+                    case "crono_enabled": self.crono_enabled = json[key]
+                    case "att_eco": self.att_eco = json[key]
+                    case "pul_brac": self.pul_brac = json[key]
+                    case "ingr_amb": self.ingr_amb = json[key]
+                    case "sens_liv_pellet": self.sens_liv_pellet = json[key]
+                    case "nome_banca_dati_sel": self.nome_banca_dati_sel = json[key]
+                    case "adaptive_on": self.adaptive_on = json[key]
+                    case "last_alarm": self.last_alarm = json[key]
+                    case "set_amb1": self.set_amb1 = json[key]
+                    case "temp_amb_install": self.temp_amb_install = json[key]
+                    case "StatusTimestamp": self.status_timestamp = json[key]
+                    case "LastSTDT": self.last_stdt = json[key]
+                    case "SiteTimeZone": self.site_time_zone = json[key]
+                    case "BlockingEventId": self.blocking_event_id = json[key]
+                    case "Description": self.description = json[key]
+                    case "IsConnected": self.is_connected = json[key]
+                    case "IsInError": self.is_in_error = json[key]
+                    case _ :
+                        temp_unknown_fields[key] = json[key]
+                        _LOGGER.warning(f"Unknown state property '{key}' received from API endpoint. If this happens, please make an issue on the github repository")
+            if temp_unknown_fields:
+                self.unknown_fields = temp_unknown_fields

--- a/custom_components/maestro_mcz/maestro/responses/status.py
+++ b/custom_components/maestro_mcz/maestro/responses/status.py
@@ -1,172 +1,192 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class Status:
-    status: str
-    stato_stufa: int
-    turbo_activation_timestamp: int
-    scheduled_turn_off_timestamp: int
-    is_crono_empty: bool
-    is_ble_connected: bool
-    sm_nome_app: str
-    sm_vs_app: int
-    mc_vs_app: str
-    fase_op: str
-    sub_fase_op: str
-    mod_lav_att: str
-    set_pot_man: int
-    set_amb1: float
-    set_amb2: float
-    set_amb3: float
-    set_vent_v1: int
-    set_vent_v2: int
-    set_vent_v3: int
-    v_ven1_v0: int
-    v_ven2_v0: int
-    v_ven3_v0: int
-    potenza_att: int
-    index_vel_v1: int
-    index_vel_v2: int
-    index_vel_v3: int
-    temp_amb_can1: float
-    temp_amb_can2: float
-    temp_amb_can3: float
-    temp_amb_install: float
-    wifi_status: int
-    silent_enabled: bool
-    crono_enabled: bool
-    sleep_enabled: bool
-    clean_air_in_prog: bool
-    clean_in_prog: bool
-    power_enabled: bool
-    silent: bool
-    t_power: int
-    att_eco: bool
-    sens_liv_pellet: bool
-    auto_pellet: int
-    sens_liv_pel: bool
-    pul_brac: bool
-    ingr_amb: int
-    rit_usc_standby: int
-    rit_ing_standby: int
-    ist_neg_amb: float
-    ist_pos_amb: float
-    ist_eco_neg_amb: float
-    ist_eco_pos_amb: float
-    com_es_car_coclea: bool
-    t_car_pel_man: int
-    pos_ric_pel: int
-    pos_ric_flu: int
-    anno: int
-    mese: int
-    giorno: int
-    ore: int
-    minuti: int
-    secondi: int
-    giorno_sett: int
-    am_pm: bool
-    pressione_pascal: int
-    pressione: int
-    pressione_imp: int
-    act: bool
-    act_acc: bool
-    ore_prox_manut: int
-    toni_buzz: int
-    mod_ada_on: bool
-    ssid_wifi: str
-    sm_sn: str
-    nome_banca_dati_sel: str
-    cont_fine_pul: bool
-    ing_term_amb1: bool
-    description: str
-    is_connected: bool
-    is_in_error: bool
-    status_timestamp: int
-    last_stdt: int
-    site_time_zone: str
-    blocking_event_id: None
+    status: str | None = None
+    stato_stufa: int | None = None
+    turbo_activation_timestamp: int | None = None
+    scheduled_turn_off_timestamp: int | None = None
+    is_crono_empty: bool | None = None
+    is_ble_connected: bool | None = None
+    sm_nome_app: str | None = None
+    sm_vs_app: int | None = None
+    mc_vs_app: str | None = None
+    fase_op: str | None = None
+    sub_fase_op: str | None = None
+    mod_lav_att: str | None = None
+    set_pot_man: int | None = None
+    set_amb1: float | None = None
+    set_amb2: float | None = None
+    set_amb3: float | None = None
+    set_vent_v1: int | None = None
+    set_vent_v2: int | None = None
+    set_vent_v3: int | None = None
+    v_ven1_v0: int | None = None
+    v_ven2_v0: int | None = None
+    v_ven3_v0: int | None = None
+    potenza_att: int | None = None
+    index_vel_v1: int | None = None
+    index_vel_v2: int | None = None
+    index_vel_v3: int | None = None
+    temp_amb_can1: float | None = None
+    temp_amb_can2: float | None = None
+    temp_amb_can3: float | None = None
+    temp_amb_install: float | None = None 
+    wifi_status: int | None = None
+    silent_enabled: bool | None = None
+    crono_enabled: bool | None = None
+    sleep_enabled: bool | None = None
+    clean_air_in_prog: bool | None = None
+    clean_in_prog: bool | None = None
+    power_enabled: bool | None = None
+    silent: bool | None = None
+    t_power: int | None = None
+    att_eco: bool | None = None
+    sens_liv_pellet: bool | None = None
+    auto_pellet: int | None = None
+    sens_liv_pel: bool | None = None
+    pul_brac: bool | None = None
+    ingr_amb: int | None = None
+    rit_usc_standby: int | None = None
+    rit_ing_standby: int | None = None
+    ist_neg_amb: float | None = None
+    ist_pos_amb: float | None = None
+    ist_eco_neg_amb: float | None = None
+    ist_eco_pos_amb: float | None = None
+    com_es_car_coclea: bool | None = None
+    t_car_pel_man: int | None = None
+    pos_ric_pel: int | None = None
+    pos_ric_flu: int | None = None
+    anno: int | None = None
+    mese: int | None = None
+    giorno: int | None = None
+    ore: int | None = None
+    minuti: int | None = None
+    secondi: int | None = None
+    giorno_sett: int | None = None
+    am_pm: bool | None = None
+    pressione_pascal: int | None = None
+    pressione: int | None = None
+    pressione_imp: int | None = None
+    act: bool | None = None
+    act_acc: bool | None = None
+    ore_prox_manut: int | None = None
+    toni_buzz: int | None = None
+    mod_ada_on: bool | None = None
+    ssid_wifi: str | None = None
+    sm_sn: str | None = None
+    nome_banca_dati_sel: str | None = None
+    cont_fine_pul: bool | None = None
+    ing_term_amb1: bool | None = None
+    description: str | None = None
+    is_connected: bool | None = None
+    is_in_error: bool | None = None
+    status_timestamp: int | None = None
+    last_stdt: int | None = None
+    site_time_zone: str | None = None
+    blocking_event_id: str | None = None
+    pren_acc: bool | None = None
+
+    unknown_fields: dict | None = None
 
     def __init__(self, json) -> None:
-        self.status = json["Status"]
-        self.stato_stufa = json["stato_stufa"]
-        self.turbo_activation_timestamp = json["TurboActivationTimestamp"]
-        self.scheduled_turn_off_timestamp = json["ScheduledTurnOffTimestamp"]
-        self.is_crono_empty = json["IsCronoEmpty"]
-        self.is_ble_connected = json["IsBLEConnected"]
-        self.sm_nome_app = json["sm_nome_app"]
-        self.sm_vs_app = json["sm_vs_app"]
-        self.mc_vs_app = json["mc_vs_app"]
-        self.fase_op = json["fase_op"]
-        self.sub_fase_op = json["sub_fase_op"]
-        self.mod_lav_att = json["mod_lav_att"]
-        self.set_pot_man = json["set_pot_man"]
-        self.set_amb1 = json["set_amb1"]
-        self.set_amb2 = json["set_amb2"]
-        self.set_amb3 = json["set_amb3"]
-        self.set_vent_v1 = json["set_vent_v1"]
-        self.set_vent_v2 = json["set_vent_v2"]
-        self.set_vent_v3 = json["set_vent_v3"]
-        self.v_ven1_v0 = json["v_ven1_v0"]
-        self.v_ven2_v0 = json["v_ven2_v0"]
-        self.v_ven3_v0 = json["v_ven3_v0"]
-        self.potenza_att = json["potenza_att"]
-        self.index_vel_v1 = json["index_vel_v1"]
-        self.index_vel_v2 = json["index_vel_v2"]
-        self.index_vel_v3 = json["index_vel_v3"]
-        self.temp_amb_can1 = json["temp_amb_can1"]
-        self.temp_amb_can2 = json["temp_amb_can2"]
-        self.temp_amb_can3 = json["temp_amb_can3"]
-        self.temp_amb_install = json["temp_amb_install"]
-        self.wifi_status = json["wifi_status"]
-        self.silent_enabled = json["silent_enabled"]
-        self.crono_enabled = json["crono_enabled"]
-        self.sleep_enabled = json["sleep_enabled"]
-        self.clean_air_in_prog = json["clean_air_in_prog"]
-        self.clean_in_prog = json["clean_in_prog"]
-        self.power_enabled = json["power_enabled"]
-        self.silent = json["silent"]
-        self.t_power = json["t_power"]
-        self.att_eco = json["att_eco"]
-        self.sens_liv_pellet = json["sens_liv_pellet"]
-        self.auto_pellet = json["auto_pellet"]
-        self.sens_liv_pel = json["sens_liv_pel"]
-        self.pul_brac = json["pul_brac"]
-        self.ingr_amb = json["ingr_amb"]
-        self.rit_usc_standby = json["rit_usc_standby"]
-        self.rit_ing_standby = json["rit_ing_standby"]
-        self.ist_neg_amb = json["ist_neg_amb"]
-        self.ist_pos_amb = json["ist_pos_amb"]
-        self.ist_eco_neg_amb = json["ist_eco_neg_amb"]
-        self.ist_eco_pos_amb = json["ist_eco_pos_amb"]
-        self.com_es_car_coclea = json["com_es_car_coclea"]
-        self.t_car_pel_man = json["t_car_pel_man"]
-        self.pos_ric_pel = json["pos_ric_pel"]
-        self.pos_ric_flu = json["pos_ric_flu"]
-        self.anno = json["anno"]
-        self.mese = json["mese"]
-        self.giorno = json["giorno"]
-        self.ore = json["ore"]
-        self.minuti = json["minuti"]
-        self.secondi = json["secondi"]
-        self.giorno_sett = json["giorno_sett"]
-        self.am_pm = json["am_pm"]
-        self.pressione_pascal = json["pressione_pascal"]
-        self.pressione = json["pressione"]
-        self.pressione_imp = json["pressione_imp"]
-        self.act = json["act"]
-        self.act_acc = json["act_acc"]
-        self.ore_prox_manut = json["ore_prox_manut"]
-        self.toni_buzz = json["toni_buzz"]
-        self.mod_ada_on = json["mod_ada_on"]
-        self.ssid_wifi = json["SSID_wifi"]
-        self.sm_sn = json["sm_sn"]
-        self.nome_banca_dati_sel = json["nome_banca_dati_sel"]
-        self.cont_fine_pul = json["cont_fine_pul"]
-        self.ing_term_amb1 = json["ing_term_amb1"]
-        self.description = json["Description"]
-        self.is_connected = json["IsConnected"]
-        self.is_in_error = json["IsInError"]
-        self.status_timestamp = json["StatusTimestamp"]
-        self.last_stdt = json["LastSTDT"]
-        self.site_time_zone = json["SiteTimeZone"]
-        self.blocking_event_id = json["BlockingEventId"]
+        if(json is not None and len(json) > 0):
+            temp_unknown_fields = {}
+            for key in json:
+                match key:
+                    case "Status": self.status = json[key]
+                    case "stato_stufa": self.stato_stufa = json[key]
+                    case "TurboActivationTimestamp": self.turbo_activation_timestamp = json[key]
+                    case "ScheduledTurnOffTimestamp": self.scheduled_turn_off_timestamp = json[key]
+                    case "IsCronoEmpty": self.is_crono_empty = json[key]
+                    case "IsBLEConnected": self.is_ble_connected = json[key]
+                    case "sm_nome_app": self.sm_nome_app = json[key]
+                    case "sm_vs_app": self.sm_vs_app = json[key]
+                    case "mc_vs_app": self.mc_vs_app = json[key]
+                    case "fase_op": self.fase_op = json[key]
+                    case "sub_fase_op": self.sub_fase_op = json[key]
+                    case "mod_lav_att": self.mod_lav_att = json[key]
+                    case "set_pot_man": self.set_pot_man = json[key]
+                    case "set_amb1": self.set_amb1 = json[key]
+                    case "set_amb2": self.set_amb2 = json[key]
+                    case "set_amb3": self.set_amb3 = json[key]
+                    case "set_vent_v1": self.set_vent_v1 = json[key]
+                    case "set_vent_v2": self.set_vent_v2 = json[key]
+                    case "set_vent_v3": self.set_vent_v3 = json[key]
+                    case "v_ven1_v0": self.v_ven1_v0 = json[key]
+                    case "v_ven2_v0": self.v_ven2_v0 = json[key]
+                    case "v_ven3_v0": self.v_ven3_v0 = json[key]
+                    case "potenza_att": self.potenza_att = json[key]
+                    case "index_vel_v1": self.index_vel_v1 = json[key]
+                    case "index_vel_v2": self.index_vel_v2 = json[key]
+                    case "index_vel_v3": self.index_vel_v3 = json[key]
+                    case "temp_amb_can1": self.temp_amb_can1 = json[key]
+                    case "temp_amb_can2": self.temp_amb_can2 = json[key]
+                    case "temp_amb_can3": self.temp_amb_can3 = json[key]
+                    case "temp_amb_install": self.temp_amb_install = json[key]
+                    case "wifi_status": self.wifi_status = json[key]
+                    case "silent_enabled": self.silent_enabled = json[key]
+                    case "crono_enabled": self.crono_enabled = json[key]
+                    case "sleep_enabled": self.sleep_enabled = json[key]
+                    case "clean_air_in_prog": self.clean_air_in_prog = json[key]
+                    case "clean_in_prog": self.clean_in_prog = json[key]
+                    case "power_enabled": self.power_enabled = json[key]
+                    case "silent": self.silent = json[key]
+                    case "t_power": self.t_power = json[key]
+                    case "att_eco": self.att_eco = json[key]
+                    case "sens_liv_pellet": self.sens_liv_pellet = json[key]
+                    case "auto_pellet": self.auto_pellet = json[key]
+                    case "sens_liv_pel": self.sens_liv_pel = json[key]
+                    case "pul_brac": self.pul_brac = json[key]
+                    case "ingr_amb": self.ingr_amb = json[key]
+                    case "rit_usc_standby": self.rit_usc_standby = json[key]
+                    case "rit_ing_standby": self.rit_ing_standby = json[key]
+                    case "ist_neg_amb": self.ist_neg_amb = json[key]
+                    case "ist_pos_amb": self.ist_pos_amb = json[key]
+                    case "ist_eco_neg_amb": self.ist_eco_neg_amb = json[key]
+                    case "ist_eco_pos_amb": self.ist_eco_pos_amb = json[key]
+                    case "com_es_car_coclea": self.com_es_car_coclea = json[key]
+                    case "t_car_pel_man": self.t_car_pel_man = json[key]
+                    case "pos_ric_pel": self.pos_ric_pel = json[key]
+                    case "pos_ric_flu": self.pos_ric_flu = json[key]
+                    case "anno": self.anno = json[key]
+                    case "mese": self.mese = json[key]
+                    case "giorno": self.giorno = json[key]
+                    case "ore": self.ore = json[key]
+                    case "minuti": self.minuti = json[key]
+                    case "secondi": self.secondi = json[key]
+                    case "giorno_sett": self.giorno_sett = json[key]
+                    case "am_pm": self.am_pm = json[key]
+                    case "pressione_pascal": self.pressione_pascal = json[key]
+                    case "pressione": self.pressione = json[key]
+                    case "pressione_imp": self.pressione_imp = json[key]
+                    case "act": self.act = json[key]
+                    case "act_acc": self.act_acc = json[key]
+                    case "ore_prox_manut": self.ore_prox_manut = json[key]
+                    case "toni_buzz": self.toni_buzz = json[key]
+                    case "mod_ada_on": self.mod_ada_on = json[key]
+                    case "SSID_wifi": self.ssid_wifi = json[key]
+                    case "sm_sn": self.sm_sn = json[key]
+                    case "nome_banca_dati_sel": self.nome_banca_dati_sel = json[key]
+                    case "cont_fine_pul": self.cont_fine_pul = json[key]
+                    case "ing_term_amb1": self.ing_term_amb1 = json[key]
+                    case "Description": self.description = json[key]
+                    case "IsConnected": self.is_connected = json[key]
+                    case "IsInError": self.is_in_error = json[key]
+                    case "StatusTimestamp": self.status_timestamp = json[key]
+                    case "LastSTDT": self.last_stdt = json[key]
+                    case "SiteTimeZone": self.site_time_zone = json[key]
+                    case "BlockingEventId": self.blocking_event_id = json[key]
+                    case "pren_acc" : self.pren_acc = json[key]
+                    case _ :
+                        temp_unknown_fields[key] = json[key]
+                        _LOGGER.warning(f"Unknown status property '{key}' received from API endpoint. If this happens, please make an issue on the github repository")
+            if temp_unknown_fields:
+                self.unknown_fields = temp_unknown_fields
+
+       
+         

--- a/custom_components/maestro_mcz/maestro/types/enums.py
+++ b/custom_components/maestro_mcz/maestro/types/enums.py
@@ -1,12 +1,5 @@
 from enum import Enum
 
-class ModeEnum(Enum):
-    manual = 0,
-    auto = 1,
-    overnight = 2,
-    comfort = 3,
-    turbo = 4
-
 class TypeEnum(Enum):
     BOOLEAN = "boolean"
     DOUBLE = "double"

--- a/custom_components/maestro_mcz/manifest.json
+++ b/custom_components/maestro_mcz/manifest.json
@@ -12,5 +12,5 @@
       "@Robbe-B"  
     ],
     "iot_class": "cloud_polling",
-    "version": "0.2.10-beta"
+    "version": "0.3.0-beta"
 }

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass, field
+from uuid import UUID
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -6,74 +8,121 @@ from homeassistant.components.sensor import (
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import TEMP_CELSIUS
 
-#FAN [name, icon, presets, fan_number, function, enabled_by_default, category]
-#SENSOR [name, unit, icon, device_class, state_class, enabled_by_default, category]
 
-GENERIC_SENSORS = {
-    "state": ["Current State", None, "mdi:power", None, None, True, EntityCategory.DIAGNOSTIC],
-    "temp_amb_install": ["Temperature", TEMP_CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True, None],
-    "mode": ["Current Mode", None, "mdi:calendar-multiselect", None, None, True, EntityCategory.DIAGNOSTIC],
-    "temp_fumi": ["Exhaust Temperature", TEMP_CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True, EntityCategory.DIAGNOSTIC],
-    "temp_scheda": ["Board Temperature", TEMP_CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True, EntityCategory.DIAGNOSTIC],
-    "mode": ["Current Mode", None, "mdi:calendar-multiselect", None, None, True, EntityCategory.DIAGNOSTIC],
-    "vel_real_ventola_fumi": ["Exhaust Fan Speed", "rpm", "mdi:fan-chevron-up", None, SensorStateClass.MEASUREMENT, True, EntityCategory.DIAGNOSTIC],
-    "vel_real_coclea": ["Transport Screw Speed", "rpm", "mdi:screw-lag", None, None, SensorStateClass.MEASUREMENT, EntityCategory.DIAGNOSTIC],
-}
+@dataclass
+class MczConfigItem:
 
-GENERIC_FANS = {
-    "set_vent_v1": ["Fan 1", "mdi:fan", {"0", "1", "2", "3", "4", "5", "6"}, 1, "Fan", True, None]
-}
+    sensor_get_name: str = field(default_factory=str) #name used for getting data out of the state and status reponses
+    sensor_set_name: str = field(default_factory=str) #name used for setting data trough the API (resolved in configs first)
+    sensor_set_config_name: str = field(default_factory=str)
 
-models = {
-    "CUTHDE08": {
-        "sensor": {
-            **GENERIC_SENSORS,
-            **{
-                # "temp_amb_install": ["Temperature", TEMP_CELSIUS, "mdi:thermometer", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True, None],
-            }
-        },
-        "fan": {
-            **GENERIC_FANS,
-            **{
-                # "set_vent_v1": ["Fan 1", ["0", "1", "2", "3", "4", "5", "6"], 1, "Fan"]
-            }
-        }
-    },
-    "SC12": {
-        "sensor": {
-            **GENERIC_SENSORS,
-        },
-        "fan": {
-            **GENERIC_FANS,
-            **{
-                "set_vent_v2": ["Fan 2", "mdi:fan", {"0", "1", "2", "3", "4", "5", "6"}, 2, "Fan", True, None],
-                "set_vent_v3": ["Fan 3", "mdi:fan", {"0", "1", "2", "3", "4", "5", "6"}, 3, "Fan", True, None]
-            }
-        }
-    },
-    "ST.SUITE": {
-        "sensor": {
-            **GENERIC_SENSORS,
-            **{
-            }
-        },
-        "fan": {
-            **GENERIC_FANS,
-            **{
-            }
-        }
-    },
+    user_friendly_name: str = field(default_factory=str)
+    icon: str = field(default_factory=str)
+    enabled_by_default: bool = True
+    category: EntityCategory | None = None
 
-    "LO08": {
-        "sensor": {
-            **GENERIC_SENSORS,
-            **{
-            }
-        },
-        "fan": {
-            **GENERIC_FANS,
-            **{
-            }
-        }
-    }
-}
+    def __init__(self, user_friendly_name:str, sensor_get_name:str) -> None:
+        self.user_friendly_name = user_friendly_name
+        self.sensor_get_name = sensor_get_name
+
+@dataclass
+class PowerSettingMczConfigItem(MczConfigItem):
+
+    def __init__(self, user_friendly_name:str,  sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = "mdi:power"
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_config_name = sensor_set_config_name
+        self.enabled_by_default = enabled_by_default
+
+@dataclass
+class ClimateFunctionModeMczConfigItem(MczConfigItem):
+    mappings: dict[str,str] = field(default_factory=list)
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool, mappings: dict[str,str]):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = "mdi:thermostat-cog"
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_config_name = sensor_set_config_name
+        self.enabled_by_default = enabled_by_default
+        self.mappings = mappings
+
+@dataclass
+class ThermostatMczConfigItem(MczConfigItem):
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = "mdi:thermostat"
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_config_name = sensor_set_config_name
+        self.enabled_by_default = enabled_by_default
+
+@dataclass
+class PotMczConfigItem(MczConfigItem):
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = "mdi:pot"
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_config_name = sensor_set_config_name
+        self.enabled_by_default = enabled_by_default
+
+@dataclass
+class SensorMczConfigItem(MczConfigItem):
+    
+    unit: str | None = None
+    device_class: SensorDeviceClass | None = None
+    state_class: SensorStateClass | None = None
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, icon:str, unit:str|None, category: EntityCategory | None, device_class: SensorDeviceClass | None, state_class: SensorStateClass | None, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = icon
+        self.unit = unit
+        self.category = category
+        self.device_class = device_class
+        self.state_class = state_class
+        self.enabled_by_default = enabled_by_default
+
+@dataclass
+class FanMczConfigItem(MczConfigItem):
+    
+    presets: list[str] = field(default_factory=list)
+
+    def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
+        super().__init__(user_friendly_name, sensor_get_name)
+        self.icon = "mdi:fan"
+        self.sensor_set_name = sensor_set_name
+        self.sensor_set_config_name = sensor_set_config_name
+        self.enabled_by_default = enabled_by_default
+
+supported_power_settings = [
+    PowerSettingMczConfigItem("Power", "fase_op", "com_on_off", "Spegnimento", True),
+]
+
+supported_climate_function_modes = [
+    ClimateFunctionModeMczConfigItem("Mode", "mode", "mod_funz", "set_mod", True, {"dynamic":"auto"}),
+]
+
+supported_thermostats = [
+    ThermostatMczConfigItem("Temperature", "set_amb1", "set_amb1", "Set_amb_temp", True),
+]
+
+supported_pots = [
+    PotMczConfigItem("Pot", "set_pot_man", "set_pot_man", "Set_pot", True)
+]
+
+supported_sensors = [
+    SensorMczConfigItem("Current State","state","mdi:power", None, EntityCategory.DIAGNOSTIC, None, None, True),
+    SensorMczConfigItem("Temperature","temp_amb_install","mdi:thermometer", TEMP_CELSIUS, None, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Current Mode","mode","mdi:calendar-multiselect", None, EntityCategory.DIAGNOSTIC, None, None, True),
+    SensorMczConfigItem("Exhaust Temperature","temp_fumi","mdi:thermometer", TEMP_CELSIUS, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Board Temperature","temp_scheda","mdi:thermometer", TEMP_CELSIUS, EntityCategory.DIAGNOSTIC, SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Exhaust Fan Speed","vel_real_ventola_fumi","mdi:fan-chevron-up", "rpm", EntityCategory.DIAGNOSTIC, None, SensorStateClass.MEASUREMENT, True),
+    SensorMczConfigItem("Transport Screw Speed","vel_real_coclea","mdi:screw-lag", "rpm", EntityCategory.DIAGNOSTIC, None, SensorStateClass.MEASUREMENT, True),
+]
+
+supported_fans = [
+    FanMczConfigItem("Fan 1", "set_vent_v1", "set_vent_v1", "set_v1", True),
+    FanMczConfigItem("Fan 2", "set_vent_v2", "set_vent_v2", "set_v2", True),
+    FanMczConfigItem("Fan 3", "set_vent_v3", "set_vent_v3", "set_v3", True),
+]

--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass, field
-from uuid import UUID
+from dataclasses import dataclass
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -11,12 +10,12 @@ from homeassistant.const import TEMP_CELSIUS
 @dataclass
 class MczConfigItem:
 
-    sensor_get_name: str = field(default_factory=str) #name used for getting data out of the state and status reponses
-    sensor_set_name: str = field(default_factory=str) #name used for setting data trough the API (resolved in configs first)
-    sensor_set_config_name: str = field(default_factory=str)
+    sensor_get_name: str | None = None #name used for getting data out of the state and status reponses
+    sensor_set_name: str | None = None #name used for setting data trough the API (resolved in configs first)
+    sensor_set_config_name: str | None = None
 
-    user_friendly_name: str = field(default_factory=str)
-    icon: str = field(default_factory=str)
+    user_friendly_name: str | None = None
+    icon: str | None = None
     enabled_by_default: bool = True
     category: EntityCategory | None = None
 
@@ -36,7 +35,7 @@ class PowerSettingMczConfigItem(MczConfigItem):
 
 @dataclass
 class ClimateFunctionModeMczConfigItem(MczConfigItem):
-    mappings: dict[str,str] = field(default_factory=list)
+    mappings: dict[str,str] | None = None
 
     def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool, mappings: dict[str,str]):
         super().__init__(user_friendly_name, sensor_get_name)
@@ -85,8 +84,6 @@ class SensorMczConfigItem(MczConfigItem):
 @dataclass
 class FanMczConfigItem(MczConfigItem):
     
-    presets: list[str] = field(default_factory=list)
-
     def __init__(self, user_friendly_name:str, sensor_get_name:str, sensor_set_name:str, sensor_set_config_name:str, enabled_by_default: bool):
         super().__init__(user_friendly_name, sensor_get_name)
         self.icon = "mdi:fan"


### PR DESCRIPTION
In this PR, a lot has been changed:
- We moved away from the manual config entry for each stove model & has been replaced with an automatic config discovery mechanism
- We don't crash anymore when a value is not found in a response (apparently this can be different for various stove models)
- We've added the unknown fields from a response message in the diagnostics file (we potentially need this in the future in order to move forward, supporting more stove models)
- Lot's of other small improvements under the hood of this integration