### PR TITLE
Add multiple ambient temperature thermostats support

### DIFF
--- a/custom_components/maestro_mcz/models.py
+++ b/custom_components/maestro_mcz/models.py
@@ -161,7 +161,9 @@ supported_climate_function_modes = [
 ]
 
 supported_thermostats = [
-    ThermostatMczConfigItem("Temperature", "set_amb1", "set_amb1", "Set_amb_temp", True),
+    ThermostatMczConfigItem("Ambient Temperature", "set_amb1", "set_amb1", "Set_amb_temp", True),
+    ThermostatMczConfigItem("Ambient Temperature 2", "set_amb2", "set_amb2", "Set_amb_temp", True),
+    ThermostatMczConfigItem("Ambient Temperature 3", "set_amb3", "set_amb3", "Set_amb_temp", True),
 ]
 
 supported_pots = [


### PR DESCRIPTION
For stoves with multiple ambient temperature thermostats , we've added these thermostats in the config to be consistent.
In the future we can expose these separately.