### PR TITLE
Fix broken API call, paged models

### DIFF
--- a/custom_components/maestro_mcz/maestro/__init__.py
+++ b/custom_components/maestro_mcz/maestro/__init__.py
@@ -90,7 +90,7 @@ class MaestroController:
         if self.Connected == False:
             await self.Login()
         res = await self.MakeRequest(
-            "GET", "https://s.maestro.mcz.it/hlapi/v1.0/Nav/Auth/FirstVisibleObjects"
+            "POST", "https://s.maestro.mcz.it/hlapi/v1.0/Nav/FirstVisibleObjectsPaginated", {}, {}
         )
 
         for stove in res:
@@ -104,7 +104,7 @@ class MaestroStove:
         self._stove = stove
         self._controller: MaestroController = controller
         self._id = stove["Node"]["Id"]
-        self._name = stove["Node"]["SensorSetName"]
+        self._name = stove["Node"]["Name"]
         self._modelid = stove["Node"]["ModelId"]
         self._sensorsettypeid = stove["Node"]["SensorSetTypeId"]
         self._uniquecode = stove["Node"]["UniqueCode"]


### PR DESCRIPTION
This should fix the broken API call in order to get the FirstVisibleObjects.
This is now changed to the replacement method to do this in a paged way => FirstVisibleObjectsPaginated

Note: This is a quick fix, didn't had the time to investigate what the content of this POST request should be, but it seems to work for now.